### PR TITLE
Implement hop-limited flood mesh algorithm

### DIFF
--- a/FisherNet/B_DistressSignal.ino
+++ b/FisherNet/B_DistressSignal.ino
@@ -1,51 +1,51 @@
 #define DISTRESS_SIGNAL_INTERVAL 30000
 
-unsigned long timeLastSignalSent = 0;
+unsigned long timeLastSignalSent;
 DistressResponse lastResponse;
 bool receivedResponse;
 // Did the user double click while in this state?
 bool didError = false;
 
 void DistressSignal_setup(AlertLevel al) {
+  // Initialize state variables
   receivedResponse = false;
   currentAlertLevel = al;
-  // Set OLED color to white
+  timeLastSignalSent = 0;
   oled.setTextColor(WHITE);
 
   // Setup button click code
-  // TODO: Move cancellation logic here
   //call BTN_1 Click functions
   button1.attachClick(handleClick);
   button1.attachDoubleClick(handleConfirm);
-  button1.attachLongPressStart(DistressSignal_BTN_1_back);
+  button1.attachLongPressStart(handleCancel);
   button1.setPressTicks(300); //time to distinguish click vs long press
   button1.setClickTicks(500); //time to distinguish click vs double click
 
   //call BTN_2 Click functions
   button2.attachClick(handleClick);
   button2.attachDoubleClick(handleConfirm);
-  button2.attachLongPressStart(DistressSignal_BTN_2_back);
+  button2.attachLongPressStart(handleCancel);
   button2.setPressTicks(300); //time to distinguish click vs long press
   button2.setClickTicks(500); //time to distinguish click vs double click
 
   //call BTN_3 Click functions
   button3.attachClick(handleClick);
   button3.attachDoubleClick(handleConfirm);
-  button3.attachLongPressStart(DistressSignal_BTN_3_back);
+  button3.attachLongPressStart(handleCancel);
   button3.setPressTicks(300); //time to distinguish click vs long press
   button3.setClickTicks(500); //time to distinguish click vs double click
 
   //call BTN_4 Click functions
   button4.attachClick(handleClick);
   button4.attachDoubleClick(handleConfirm);
-  button4.attachLongPressStart(DistressSignal_BTN_4_back);
+  button4.attachLongPressStart(handleCancel);
   button4.setPressTicks(300); //time to distinguish click vs long press
   button4.setClickTicks(500); //time to distinguish click vs double click
 
   //call BTN_5 Click functions
   button5.attachClick(handleClick);
   button5.attachDoubleClick(handleConfirm);
-  button5.attachLongPressStart(DistressSignal_BTN_5_back);
+  button5.attachLongPressStart(handleCancel);
   button5.setPressTicks(300); //time to distinguish click vs long press
   button5.setClickTicks(500); //time to distinguish click vs double click
 }
@@ -60,31 +60,7 @@ void handleConfirm() {
 }
 
 //LONG PRESS FUNCTIONS
-void DistressSignal_BTN_1_back() {
-  cancelmessage();
-  delay(2000);
-  changeProgramState(DEFAULT_MENU);
-}
-
-void DistressSignal_BTN_2_back() {
-  cancelmessage();
-  delay(2000);
-  changeProgramState(DEFAULT_MENU);
-}
-
-void DistressSignal_BTN_3_back() {
-  cancelmessage();
-  delay(2000);
-  changeProgramState(DEFAULT_MENU);
-}
-
-void DistressSignal_BTN_4_back() {
-  cancelmessage();
-  delay(2000);
-  changeProgramState(DEFAULT_MENU);
-}
-
-void DistressSignal_BTN_5_back() {
+void handleCancel() {
   cancelmessage();
   delay(2000);
   changeProgramState(DEFAULT_MENU);

--- a/FisherNet/B_DistressSignal.ino
+++ b/FisherNet/B_DistressSignal.ino
@@ -94,7 +94,7 @@ void DistressSignal_loop() {
   // When did we last broadcast?
   // If more than 30 seconds passed, we can broadcast again
   unsigned long currentTime = millis();
-  if (currentTime - timeLastSignalSent >= DISTRESS_SIGNAL_INTERVAL)
+  if (currentTime - timeLastSignalSent >= DISTRESS_SIGNAL_INTERVAL || timeLastSignalSent == 0)
   {
     // Retrieve data to be sent (e.g., GPS, Alert Level)
     float gpsLat;

--- a/FisherNet/C_Rescuer.ino
+++ b/FisherNet/C_Rescuer.ino
@@ -84,7 +84,7 @@ void Rescuer_loop() {
   String str[8] = {"","","","","","","",""};
   situation = getSituation();
 #ifdef DEBUG_MODE
-  Serial.println("Situation: " + String(situation));
+  // Serial.println("Situation: " + String(situation));
 #endif
   
   switch(situation){
@@ -189,8 +189,8 @@ void Rescuer_loop() {
   } // situation switch
 
 #ifdef DEBUG_MODE
-  Serial.print("distAcc: ");
-  Serial.println(distAcc);
+  // Serial.print("distAcc: ");
+  // Serial.println(distAcc);
 #endif
 }
 

--- a/FisherNet/C_Rescuer.ino
+++ b/FisherNet/C_Rescuer.ino
@@ -124,6 +124,8 @@ void Rescuer_loop() {
       str[6] = "BTN 1 RESCUE";
       str[7] = "BTN 2 IGNORE";
 
+      // Add a listen here to allow the node to still pass on messages
+      mesh.listenForDistressSignal();
       showInOled(str);
       break;
     case 4:

--- a/FisherNet/FisherMesh.h
+++ b/FisherNet/FisherMesh.h
@@ -176,7 +176,7 @@ bool FisherMesh::sendDistressSignal(float gpsLat, float gpsLong, AlertLevel aler
       // Pass in the distressSignal as an array of bytes
       (uint8_t *)_buffer,
       sizeof(_distressSignal),
-      // Broadcast the signal instead of directing the signal to the 
+      // Broadcast the signal instead of directing the signal to a specific node
       RH_BROADCAST_ADDRESS) == RH_ROUTER_ERROR_NONE) {
         
         // The signal has been reliably delivered to a node.
@@ -232,11 +232,10 @@ bool FisherMesh::listenForDistressSignal() {
         memcpy(_buffer, distressSignal, sizeof(DistressSignal));
         
         // Rebroadcast the signal while mimicking the source
-        _manager.sendtoFromSourceWait(  
+        _manager.sendtoWait(  
           (uint8_t *)_buffer,
           sizeof(DistressSignal),
-          RH_BROADCAST_ADDRESS,
-          from);
+          RH_BROADCAST_ADDRESS);
       } 
       return true;
     }

--- a/FisherNet/FisherNet.ino
+++ b/FisherNet/FisherNet.ino
@@ -1,5 +1,5 @@
 /**
- * FisherNet v2.0
+ * FisherNet v2.2
  * November 27, 2021
  * 
  * In fulfillment of the final project requirement
@@ -22,7 +22,7 @@
 //  **IMPORTANT!!** Uncomment the device you are using
 #define LILYGO
 // #define EGIZMO
-// #define DEBUG_MODE
+#define DEBUG_MODE
 
 #include "PinAssignments.h"
 


### PR DESCRIPTION
As inspired by [the Meshtastic broadcast algorithm](https://meshtastic.org/docs/developers/device/mesh-alg#layer-3-naive-flooding-for-multi-hop-messaging), the distress signal will now follow a predefined hop limit (i.e., it can only be rebroadcasted a limited number of times) to prevent having a [broadcast storm](https://en.wikipedia.org/wiki/Broadcast_storm) when a vessel sends a distress signal to the network.